### PR TITLE
Update update_kali.sh

### DIFF
--- a/update_kali.sh
+++ b/update_kali.sh
@@ -88,7 +88,7 @@ display_menu() {
 }
 
 # Check if no arguments were provided
-if [ $# -eq 0 ]; então
+if [ $# -eq 0 ]; then
     show_usage
     exit 1
 fi


### PR DESCRIPTION
Error Description: The script encountered a syntax error near the token fi. This error occurred because of a misplaced or missing keyword in the if statement block.

Fix: The syntax error was corrected by ensuring that the if statement is properly closed with fi in the correct place. This adjustment allows the script to run without syntax errors.